### PR TITLE
修正了 Client 的一些配置，编写了基本的 Hit 逻辑，定义了 getRule() 做测试

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/gin-gonic/gin v1.7.4
 	github.com/jinzhu/gorm v1.9.16
+	github.com/spf13/cast v1.4.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -75,7 +75,10 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
+github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
+github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/src/model/clientInfo.go
+++ b/src/model/clientInfo.go
@@ -3,7 +3,7 @@ package model
 type Client struct {
 	Version           string `json:"version" binding:"required"`
 	DevicePlatform    string `json:"device_platform" binding:"required"`
-	DeviceId          string `json:" device_id" binding:"required"`
+	DeviceId          string `json:"device_id" binding:"required"`
 	OsApi             string `json:"os_api" binding:"required"`
 	Channel           string `json:"channel" binding:"required"`
 	VersionCode       string `json:"version_code" binding:"required"`

--- a/src/model/rules.go
+++ b/src/model/rules.go
@@ -34,9 +34,29 @@ func init() {
 	Db = db
 }
 
-//func GetRules() *[]Rule {
-//
-//}
+//noinspection ALL
+func GetRules() *[]Rule {
+	// 编写测试用 rules
+	res := []Rule{
+		Rule{
+			1,
+			"Android",
+			"downloadUrl1",
+			"1.2.1",
+			"md51",
+			"device_1, device_2",
+			"1.1",
+			"1.0",
+			10,
+			5,
+			"64",
+			"华为",
+			"弹窗1",
+			"新版本1",
+		},
+	}
+	return &res
+}
 
 func AddRule(rule Rule) bool {
 	Db.AutoMigrate(&Rule{})

--- a/src/service/check.go
+++ b/src/service/check.go
@@ -1,12 +1,84 @@
 package service
 
-import "demo1/src/model"
+import (
+	"demo1/src/model"
+	"github.com/spf13/cast"
+	"math/rand"
+)
 
 func Hit(form model.Client) (string, string, string, string, string) {
 	//todo
-
+	
 	//if hit,
 	//return downloadUrl, updateVersionCode, md5, title, updateTips
+	
+	var downloadUrl, updateVersionCode, md5, title, updateTips string
+	
+	//需要 model 层实现返回规则集的接口
+	//var rules *[]model.Rule
+	rules := model.GetRules()
+	//order by updateVersionCode, use quickSort O(nlogn)
+	quickSort(rules, 0, len(*rules)-1)
+	
+	//O(n)
+	for _, rule := range *rules {
+		if matchRule(&rule, &form) {
+			downloadUrl, updateVersionCode, md5, title, updateTips = getDownloadInfo(&rule)
+			break
+		}
+	}
+	return downloadUrl, updateVersionCode, md5, title, updateTips
+}
 
-	return "11", "22", "33", "44", "55"
+func quickSort(rules *[]model.Rule, l, r int) {
+	if l >= r {
+		return
+	}
+
+	mid := l
+	randIdx := rand.Intn(r-l+1) + l
+	(*rules)[l], (*rules)[randIdx] = (*rules)[randIdx], (*rules)[l]
+	target := (*rules)[l].UpdateVersionCode
+	for i, rule := range (*rules)[l : r+1] {
+		if rule.UpdateVersionCode <= target {
+			(*rules)[mid], (*rules)[l+i] = (*rules)[l+i], (*rules)[mid]
+			mid++
+		}
+	}
+	//左侧 小于等于 target
+	//右侧 大于 target
+	quickSort(rules, l, mid-1)
+	quickSort(rules, mid, r)
+	return
+}
+
+func matchRule(rule *model.Rule, form *model.Client) bool {
+	//model.Client.Version : 请求api版本，⽐如v1/v2
+	//model.Client.version_code : 应⽤⼤版本，⽐如8.1.4
+	//deviceIdList 白名单，model 里处理
+	if form.DevicePlatform != rule.Platform {
+		//设备平台
+		return false
+	}
+	if cast.ToInt(form.Aid) != rule.Aid {
+		//app 是否相同
+		return false
+	}
+	if (*rule).Channel != (*form).Channel {
+		//渠道 是否相同
+		return false
+	}
+	if (*form).UpdateVersionCode < (*rule).MinUpdateVersionCode || (*form).UpdateVersionCode > (*rule).MaxUpdateVersionCode {
+		//是否符合 版本要求（应⽤⼩版本，⽐如8.1.4.01）
+		return false
+	}
+	if cast.ToInt((*form).OsApi) < (*rule).MinOsApi || cast.ToInt((*form).OsApi) > (*rule).MaxOsApi {
+		//系统 是否适配
+		return false
+	}
+	return true
+}
+
+func getDownloadInfo(rule *model.Rule) (string, string, string, string, string) {
+	return (*rule).DownloadUrl, (*rule).UpdateTips, (*rule).Md5, (*rule).Title, (*rule).UpdateTips
 }


### PR DESCRIPTION
更正了 /src/model/clientInfo.go 中 Client.DeviceId 的配置中 json 多余的空格; 为方便测试，在 /src/model/rules.go 中声明了 GetRules 函数，并编写了测试用数据以返回；实现了最基础的 check，排序后依此遍历规则进行匹配，若命中则返回 downloadUrl 等参数，在 check 中使用了课程中 mentor 使用的 cast 库用作类型转换，所以在 /go.mod 中添加了对 cast库 的require条目