### PR TITLE
更改了 Hit 函数的参数类型和 check 逻辑

### DIFF
--- a/src/controller/control.go
+++ b/src/controller/control.go
@@ -33,7 +33,7 @@ func Check(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
-	downloadUrl, updateVersionCode, md5, title, updateTips := service.Hit(form)
+	downloadUrl, updateVersionCode, md5, title, updateTips := service.Hit(&form)
 	c.JSON(http.StatusOK, gin.H{
 		"download_url:":       downloadUrl,
 		"update_version_code": updateVersionCode,


### PR DESCRIPTION
更改了 Hit 函数的检查逻辑，先使用二分查找其版本范围；更改 Hit 函数的参数类型为指针，在并发时减少 model.Client 参数的copy